### PR TITLE
Fix permanent redirect error (see #2)

### DIFF
--- a/libs/subtitles.py
+++ b/libs/subtitles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2011 Jörn Schumacher, Henning Saul 
-# Copyright 2021 Christian Prasch 
+# Copyright 2011 Jörn Schumacher, Henning Saul
+# Copyright 2021 Christian Prasch
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ class SubtitlesContentHandler(xml.sax.ContentHandler):
         self._result = ""
         self._count = 0
         self._line = False
- 
+
     def startElement(self, name, attrs):
         if name == "tt:p":
             self._startEntry(attrs.get("begin"), attrs.get("end"))
@@ -40,20 +40,20 @@ class SubtitlesContentHandler(xml.sax.ContentHandler):
         if name == "tt:p":
             self._endEntry()
         elif name == "tt:span":
-            self._endLine()    
+            self._endLine()
         elif name == "tt:br":
-            self._newLine()    
-             
+            self._newLine()
+
     def characters(self, content):
         if(self._line):
             self._result += content
 
     def _startEntry(self, begin, end):
         """Start a new entry in SRT format.
-        
+
         Args:
             begin: timestamp in format hh:mm:ss.mmm
-            end: timestamp in format hh:mm:ss.mmm            
+            end: timestamp in format hh:mm:ss.mmm
         """
         self._count = self._count + 1
         self._result += str(self._count)
@@ -62,43 +62,43 @@ class SubtitlesContentHandler(xml.sax.ContentHandler):
         self._result += " --> "
         self._result += end.replace('.', ',')
         self._result += "\n"
-    
+
     def _endEntry(self):
         """Ends the current SRT entry."""
-        self._result += "\n\n"        
-    
+        self._result += "\n\n"
+
     def _startLine(self):
         """Starts a line for current SRT entry."""
         self._line = True
-        
+
     def _endLine(self):
         """Ends line for current SRT entry."""
         self._line = False
-   
+
     def _newLine(self):
         """Appends new line for current SRT entry."""
         self._result += "\n"
-                 
+
     def result(self):
         """Returns the parsed result in SRT format.
 
         Returns:
             A single String for the parsed result in SRT format.
         """
-        return self._result 
+        return self._result
 
 def download_subtitles(url, subtitles_dir):
     """Downloads and parses TTML subtitles from the given URL and saves it as tagesschau.de.srt in the given subtitles directory.
-    
+
     If downloading or parsing fails, returns None.
-    
+
     Args:
         url: URL of TTML subtiles
         subtitles_dir: Directory to save parsed SRT file to
 
     Returns:
         File handle of the parsed SRT, or None
-    """    
+    """
     if not os.path.exists(subtitles_dir):
         os.makedirs(subtitles_dir)
 
@@ -109,7 +109,7 @@ def download_subtitles(url, subtitles_dir):
 
     if not url:
         return None
-    
+
     logger = logging.getLogger("plugin.video.tagesschau.subtitles")
     try:
         source = urllib.request.urlopen(url)
@@ -125,4 +125,4 @@ def download_subtitles(url, subtitles_dir):
     except urllib.error.HTTPError:
         # the only way to find out if we have subtitles is to try to retrieve them
         logger.debug("Received HTTP error for " + url)
-        return None        
+        return None

--- a/libs/tagesschau.py
+++ b/libs/tagesschau.py
@@ -136,7 +136,7 @@ def tagesschau():
                    # try to download and and convert subtitles to local SRT file
                    # as of October 2014, only subtiles for complete "tagesschau" broadcasts are available
                    # subtitles_url = 'http://www.tagesschau.de/multimedia/video/video-29351~subtitle.html'
-                   subtitles_url = 'http://www.tagesschau.de/multimedia/video/' + str(video.video_id()) + '~subtitle.html'        
+                   subtitles_url = 'https://www.tagesschau.de/multimedia/video/' + str(video.video_id()) + '~subtitle.html'        
                    subtitles_file = download_subtitles(subtitles_url, subtitles_dir)
                    
        listitem = xbmcgui.ListItem(path=url)

--- a/libs/tagesschau.py
+++ b/libs/tagesschau.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2011 Jörn Schumacher, Henning Saul 
-# Copyright 2021 Christian Prasch 
+# Copyright 2011 Jörn Schumacher, Henning Saul
+# Copyright 2021 Christian Prasch
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,7 +51,7 @@ strings = { 'latest_videos':       language(30100),
 #-- Subtitles ------------------------------------------------
 
 profile_dir = xbmcvfs.translatePath(addon.getAddonInfo('profile'))
-subtitles_dir  = os.path.join(profile_dir, 'Subtitles') 
+subtitles_dir  = os.path.join(profile_dir, 'Subtitles')
 
 # ------------------------------------------------------------
 
@@ -62,9 +62,9 @@ def addVideoContentDirectory(title, method):
     li = xbmcgui.ListItem(str(title))
     li.setArt({'thumb':DEFAULT_IMAGE_URL})
     li.setProperty('Fanart_Image', FANART)
-    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=li, isFolder=True)    
-    
-def getListItem(videocontent):    
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=li, isFolder=True)
+
+def getListItem(videocontent):
     title = str(videocontent.title)
     image_url = videocontent.image_url()
     if(not image_url):
@@ -88,10 +88,10 @@ def getUrl(videocontent, method):
     else:
         url_data[URL_PARAM] = urllib.parse.quote(videocontent.video_url(quality))
     return 'plugin://' + ADDON_ID + '?' + urllib.parse.urlencode(url_data)
-    
+
 def addVideoContentItem(videocontent, method):
     li = getListItem(videocontent)
-    url = getUrl(videocontent, method)  
+    url = getUrl(videocontent, method)
     return xbmcplugin.addDirectoryItem(int(sys.argv[1]), url, li, False)
 
 def addVideoContentItems(videocontents, method):
@@ -99,21 +99,21 @@ def addVideoContentItems(videocontents, method):
     for videocontent in videocontents:
         li = getListItem(videocontent)
         url = getUrl(videocontent, method)
-        items.append((url, li, False))   
+        items.append((url, li, False))
     return xbmcplugin.addDirectoryItems(int(sys.argv[1]), items, len(items))
 
 def get_params():
     paramstring = sys.argv[2]
     params = urllib.parse.parse_qs(urllib.parse.urlparse(paramstring).query)
-    
+
     for key in params:
         params[key] = params[key][0]
     return params
-    
+
 
 def tagesschau():
    # TODO: can't figure out how to set fanart for root/back folder of plugin
-   # http://trac.xbmc.org/ticket/8228? 
+   # http://trac.xbmc.org/ticket/8228?
    xbmcplugin.setPluginFanart(int(sys.argv[1]), 'special://home/addons/' + ADDON_ID + '/resources/assets/fanart.jpg')
 
    params = get_params()
@@ -124,10 +124,10 @@ def tagesschau():
        # expecting either url or feed and id param
        url = params.get(URL_PARAM)
        if url:
-           url = urllib.parse.unquote(url) 
-       else: 
+           url = urllib.parse.unquote(url)
+       else:
            videos_method = getattr(provider, params[FEED_PARAM])
-           videos = videos_method()    
+           videos = videos_method()
            tsid = urllib.parse.unquote(params[ID_PARAM])
            # find video with matching tsid
            for video in videos:
@@ -136,9 +136,9 @@ def tagesschau():
                    # try to download and and convert subtitles to local SRT file
                    # as of October 2014, only subtiles for complete "tagesschau" broadcasts are available
                    # subtitles_url = 'http://www.tagesschau.de/multimedia/video/video-29351~subtitle.html'
-                   subtitles_url = 'https://www.tagesschau.de/multimedia/video/' + str(video.video_id()) + '~subtitle.html'        
+                   subtitles_url = 'https://www.tagesschau.de/multimedia/video/' + str(video.video_id()) + '~subtitle.html'
                    subtitles_file = download_subtitles(subtitles_url, subtitles_dir)
-                   
+
        listitem = xbmcgui.ListItem(path=url)
        if(subtitles_file != None):
            # the following only works in Gotham, see
@@ -161,11 +161,11 @@ def tagesschau():
        if(len(videos) == 1):
            addVideoContentItem(videos[0], "livestreams")
 
-       # add directories for other feeds        
+       # add directories for other feeds
        add_named_directory = lambda x: addVideoContentDirectory(strings[x], x)
        add_named_directory('latest_videos')
        add_named_directory('latest_broadcasts')
        add_named_directory('dossiers')
        add_named_directory('archived_broadcasts')
-           
+
    xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/libs/tagesschau_json_api.py
+++ b/libs/tagesschau_json_api.py
@@ -358,26 +358,26 @@ class JsonSource(object):
     
     def livestreams(self):
         """Returns the parsed JSON structure for livestreams."""
-        handle = urllib.request.urlopen("http://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json")
+        handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json")
         return json.loads(handle.read())
 
     def latest_videos(self):
         """Returns the parsed JSON structure for the latest videos."""        
-        handle = urllib.request.urlopen("http://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json")
+        handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json")
         return json.loads(handle.read())
 
     def dossiers(self):
         """Returns the parsed JSON structure for the dossiers."""        
-        handle = urllib.request.urlopen("http://www.tagesschau.de/api/multimedia/video/ondemanddossier100.json")
+        handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/video/ondemanddossier100.json")
         return json.loads(handle.read())
 
     def latest_broadcasts(self):
         """Returns the parsed JSON structure for the latest broadcasts."""        
-        handle = urllib.request.urlopen("http://www.tagesschau.de/api/multimedia/sendung/letztesendungen100.json")
+        handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/sendung/letztesendungen100.json")
         return json.loads(handle.read())
 
     def archived_broadcasts(self):
         """Returns the parsed JSON structure for the archived broadcasts."""        
-        handle = urllib.request.urlopen("http://www.tagesschau.de/api/multimedia/sendung/letztesendungen100~_week-true.json")
+        handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/sendung/letztesendungen100~_week-true.json")
         return json.loads(handle.read())
         

--- a/libs/tagesschau_json_api.py
+++ b/libs/tagesschau_json_api.py
@@ -1,6 +1,6 @@
 #
-# Copyright 2012 Henning Saul, Joern Schumacher 
-# Copyright 2021 Christian Prasch 
+# Copyright 2012 Henning Saul, Joern Schumacher
+# Copyright 2021 Christian Prasch
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ class VideoContent(object):
         videourls: A dict mapping video variant Strings to their URL Strings
         duration: An integer representing the length of the video in seconds
         description: A String describing the video content
-    """       
+    """
     def __init__(self, tsid, title, timestamp, videourls=None, imageurls=None, duration=None, description=""):
         """Inits VideoContent with the given values."""
         self.tsid = tsid
@@ -48,15 +48,15 @@ class VideoContent(object):
         self.duration = duration
         # description of content
         self.description = description
-    
+
     def video_id(self):
         return self.tsid
-        
+
     def video_url(self, quality):
         """Returns the video URL String for the given quality.
-        
+
         Falls back to lower qualities if no corresponding video is found.
-        
+
         Args:
             quality: One of 'S', 'M', 'L' or 'X'
 
@@ -77,11 +77,11 @@ class VideoContent(object):
             videourl = self._videourls.get("h264l")
             if not videourl:
                 videourl = self._videourls.get("http_tab_high")
-        if quality == 'M' or not videourl:    
+        if quality == 'M' or not videourl:
             videourl = self._videourls.get("h264m")
             if not videourl:
                 videourl = self._videourls.get("http_tab_normal")
-        if quality == 'S' or not videourl:    
+        if quality == 'S' or not videourl:
             videourl = self._videourls.get("h264s")
             if not videourl:
                 videourl = self._videourls.get("http_tab_normal")
@@ -94,13 +94,13 @@ class VideoContent(object):
             # fallback for Wetter
             imageurl = self._imageurls.get("grossgalerie16x9")
         return imageurl
-         
+
     def __str__(self):
         """Returns a String representation for development/testing."""
         if(self.timestamp):
             tsformatted = self.timestamp.isoformat()
         else:
-            tsformatted = str(None)      
+            tsformatted = str(None)
         s = "VideoContent(tsid=" + self.tsid + ", title='" + self.title + "', timestamp=" + tsformatted + ", "\
             "duration=" + str(self.duration) + ", videourl=" + str(self.video_url('L')) + ", "\
             "imageurl=" + str(self.image_url()) + ", description='" + str(self.description) + "')"
@@ -118,7 +118,7 @@ class LazyVideoContent(VideoContent):
         detailsurl: A String pointing to the detail JSON for this video
         duration: An integer representing the length of the video in seconds
         description: A String describing the video content
-    """  
+    """
     def __init__(self, tsid, title, timestamp, detailsurl, imageurls=None, duration=None, description=""):
         VideoContent.__init__(self, tsid, title, timestamp, None, imageurls, duration, description)
         self.detailsurl = detailsurl
@@ -132,27 +132,27 @@ class LazyVideoContent(VideoContent):
         if(not self.detailsfetched):
             self._fetch_details()
         return self._videoid
-          
+
     def video_url(self, quality):
         """Overwritten to fetch videourls lazily."""
         if(not self.detailsfetched):
             self._fetch_details()
-        return VideoContent.video_url(self, quality)    
-    
+        return VideoContent.video_url(self, quality)
+
     def _fetch_details(self):
         """Fetches videourls from detailsurl."""
         self._logger.info("fetching details from " + self.detailsurl)
         handle = urllib.request.urlopen(self.detailsurl)
         jsondetails = json.load(handle)
-        self._videourls = self._parser.parse_video_urls(jsondetails["fullvideo"][0]["mediadata"])       
+        self._videourls = self._parser.parse_video_urls(jsondetails["fullvideo"][0]["mediadata"])
         self._videoid = jsondetails["fullvideo"][0]["sophoraId"]
         self.detailsfetched = True
         self._logger.info("fetched details")
 
 
 class VideoContentParser(object):
-    """Parses JSON/Python structure into VideoContent.""" 
-    
+    """Parses JSON/Python structure into VideoContent."""
+
     def parse_video(self, jsonvideo):
         """Parses the video JSON into a VideoContent object."""
         tsid = jsonvideo["sophoraId"]
@@ -166,8 +166,8 @@ class VideoContentParser(object):
         if("inMilli" in jsonvideo and "outMilli" in jsonvideo):
             duration = (jsonvideo["outMilli"] - jsonvideo["inMilli"]) / 1000
         else:
-            duration = None    
-        return VideoContent(tsid, title, timestamp, videourls, imageurls, duration)    
+            duration = None
+        return VideoContent(tsid, title, timestamp, videourls, imageurls, duration)
 
     def parse_ts_100_sek(self, jsonvideo):
         """Parses the video JSON into a VideoContent object."""
@@ -189,7 +189,7 @@ class VideoContentParser(object):
         else:
             duration = None
         #xbmc.log(title)
-        return VideoContent(tsid, title, timestamp, videourls, imageurls, duration)    
+        return VideoContent(tsid, title, timestamp, videourls, imageurls, duration)
 
 
     def parse_broadcast(self, jsonbroadcast, timestring = '%d.%m.%Y'):
@@ -213,7 +213,7 @@ class VideoContentParser(object):
         title = "Livestream: " + jsonlivestream["title"]
         timestamp = None
         imageurls = self._parse_image_urls(jsonlivestream["images"][0]["variants"])
-        videourls = self.parse_video_urls(jsonlivestream["mediadata"]) 
+        videourls = self.parse_video_urls(jsonlivestream["mediadata"])
         return VideoContent(tsid, title, timestamp, videourls, imageurls)
 
     def parse_livestreams(self, jsonlivestreams):
@@ -221,9 +221,9 @@ class VideoContentParser(object):
         videos = []
         for jsonvideo in jsonlivestreams:
             # only add livestream if on the air now...
-            if(jsonvideo["live"] == "true"):               
+            if(jsonvideo["live"] == "true"):
                 video = self._parse_livestream(jsonvideo)
-                videos.append(video)            
+                videos.append(video)
         return videos
 
     def parse_video_urls(self, jsonvariants):
@@ -243,7 +243,7 @@ class VideoContentParser(object):
         return datetime.datetime(*list(map(int, re.split('[^\d]', isodate))))
 
     def _parse_image_urls(self, jsonvariants):
-        """Parses the image variants JSON into a dict mapping variant name to URL.""" 
+        """Parses the image variants JSON into a dict mapping variant name to URL."""
         variants = {}
         for jsonvariant in jsonvariants:
             for name, url in list(jsonvariant.items()):
@@ -252,8 +252,8 @@ class VideoContentParser(object):
 
 
 class VideoContentProvider(object):
-    """Provides access to the VideoContent offered by the tagesschau JSON API.""" 
-    
+    """Provides access to the VideoContent offered by the tagesschau JSON API."""
+
     def __init__(self, jsonsource):
         self._jsonsource = jsonsource
         self._parser = VideoContentParser()
@@ -261,7 +261,7 @@ class VideoContentProvider(object):
 
     def livestreams(self):
         """Retrieves the livestream(s) currently on the air.
-        
+
             Returns:
                 A list of VideoContent object for livestream(s) on the air.
         """
@@ -270,14 +270,14 @@ class VideoContentProvider(object):
         data = self._jsonsource.livestreams()
         if("multimedia" in data):
             multimedia = data["multimedia"]
-            if("livestreams" in multimedia[0]):  
-                videos = self._parser.parse_livestreams(multimedia[0]["livestreams"])         
-        return videos    
+            if("livestreams" in multimedia[0]):
+                videos = self._parser.parse_livestreams(multimedia[0]["livestreams"])
+        return videos
 
     def latest_videos(self):
         """Retrieves the latest videos.
-            
-            Returns: 
+
+            Returns:
                 A list of VideoContent items.
         """
         self._logger.info("retrieving videos")
@@ -285,8 +285,8 @@ class VideoContentProvider(object):
         data = self._jsonsource.latest_videos()
         for jsonvideo in data["videos"]:
             video = self._parser.parse_video(jsonvideo)
-            videos.append(video) 
-    
+            videos.append(video)
+
         videos.append(self.tagesschau_in_100_sek())
 
         self._logger.info("found " + str(len(videos)) + " videos")
@@ -297,32 +297,32 @@ class VideoContentProvider(object):
         data = self._jsonsource.latest_videos()
         if("multimedia" in data):
             multimedia = data["multimedia"]
-            if("tsInHundredSeconds" in multimedia[1]):  
+            if("tsInHundredSeconds" in multimedia[1]):
                 #xbmc.log(multimedia[1])
                 video = self._parser.parse_ts_100_sek(multimedia[1]["tsInHundredSeconds"])
         return video
 
     def dossiers(self):
         """Retrieves the latest dossier videos.
-            
-            Returns: 
+
+            Returns:
                 A list of VideoContent items.
-        """    
+        """
         self._logger.info("retrieving videos")
         videos = []
         data = self._jsonsource.dossiers()
         for jsonvideo in data["videos"]:
             video = self._parser.parse_video(jsonvideo)
-            videos.append(video)  
-        self._logger.info("found " + str(len(videos)) + " videos")            
+            videos.append(video)
+        self._logger.info("found " + str(len(videos)) + " videos")
         return videos
 
     def latest_broadcasts(self):
         """Retrieves the latest broadcast videos.
-            
-            Returns: 
+
+            Returns:
                 A list of VideoContent items.
-        """        
+        """
         self._logger.info("retrieving videos")
         videos = []
         data = self._jsonsource.latest_broadcasts()
@@ -333,51 +333,50 @@ class VideoContentProvider(object):
         videos.append(self.tagesschau_in_100_sek())
         videos.append(self._parser.parse_broadcast(data["latestBroadcast"], '%d.%m.%Y %H:%M'))
 
-        self._logger.info("found " + str(len(videos)) + " videos")              
+        self._logger.info("found " + str(len(videos)) + " videos")
         return videos
 
     def archived_broadcasts(self):
         """Retrieves the archive broadcast videos.
-            
-            Returns: 
+
+            Returns:
                 A list of VideoContent items.
-        """        
-        self._logger.info("retrieving videos") 
+        """
+        self._logger.info("retrieving videos")
         videos = []
         data = self._jsonsource.archived_broadcasts()
         for jsonbroadcast in data["latestBroadcastsPerType"]:
             video = self._parser.parse_broadcast(jsonbroadcast)
             videos.append(video)
-        self._logger.info("found " + str(len(videos)) + " videos")              
+        self._logger.info("found " + str(len(videos)) + " videos")
         return videos
 
 
 class JsonSource(object):
     """Provides access to the raw objects parsed from the TS JSON API.
         Can be replaced for unittesting purposes."""
-    
+
     def livestreams(self):
         """Returns the parsed JSON structure for livestreams."""
         handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json")
         return json.loads(handle.read())
 
     def latest_videos(self):
-        """Returns the parsed JSON structure for the latest videos."""        
+        """Returns the parsed JSON structure for the latest videos."""
         handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json")
         return json.loads(handle.read())
 
     def dossiers(self):
-        """Returns the parsed JSON structure for the dossiers."""        
+        """Returns the parsed JSON structure for the dossiers."""
         handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/video/ondemanddossier100.json")
         return json.loads(handle.read())
 
     def latest_broadcasts(self):
-        """Returns the parsed JSON structure for the latest broadcasts."""        
+        """Returns the parsed JSON structure for the latest broadcasts."""
         handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/sendung/letztesendungen100.json")
         return json.loads(handle.read())
 
     def archived_broadcasts(self):
-        """Returns the parsed JSON structure for the archived broadcasts."""        
+        """Returns the parsed JSON structure for the archived broadcasts."""
         handle = urllib.request.urlopen("https://www.tagesschau.de/api/multimedia/sendung/letztesendungen100~_week-true.json")
         return json.loads(handle.read())
-        

--- a/libs/tagesschau_json_api.py
+++ b/libs/tagesschau_json_api.py
@@ -142,7 +142,17 @@ class LazyVideoContent(VideoContent):
     def _fetch_details(self):
         """Fetches videourls from detailsurl."""
         self._logger.info("fetching details from " + self.detailsurl)
-        handle = urllib.request.urlopen(self.detailsurl)
+        try:
+            handle = urllib.urlopen(self.detailsurl)
+        except urllib.HTTPError as e:
+            # check if we need to switch to https.
+            if self.detailsurl.startswith("http:"):
+                self._logger.info("failed. try with https instead")
+                handle = urllib.urlopen("https:" + self.detailsurl[5:])
+            else:
+                # whatever. Let somebody else handle that (in fact nobody will - kodi will just show an error)
+                raise e
+
         jsondetails = json.load(handle)
         self._videourls = self._parser.parse_video_urls(jsondetails["fullvideo"][0]["mediadata"])
         self._videoid = jsondetails["fullvideo"][0]["sophoraId"]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2011 Jörn Schumacher, Henning Saul 
-# Copyright 2021 Christian Prasch 
+# Copyright 2011 Jörn Schumacher, Henning Saul
+# Copyright 2021 Christian Prasch
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
tagesschau.de now automatically redirects from http to https.

```
wget http://www.tagesschau.de/api/multimedia/video/ondemand100\~_type-video.json 
--2022-03-22 22:45:36--  http://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json
Auflösen des Hostnamens www.tagesschau.de (www.tagesschau.de) … 2a02:26f0:1300:3b4::1ff2, 2a02:26f0:1300:38c::1ff2, 104.121.189.121
Verbindungsaufbau zu www.tagesschau.de (www.tagesschau.de)|2a02:26f0:1300:3b4::1ff2|:80 … verbunden.
HTTP-Anforderung gesendet, auf Antwort wird gewartet … 308 Permanent Redirect
Platz: https://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json [folgend]
--2022-03-22 22:45:36--  https://www.tagesschau.de/api/multimedia/video/ondemand100~_type-video.json
Verbindungsaufbau zu www.tagesschau.de (www.tagesschau.de)|2a02:26f0:1300:3b4::1ff2|:443 … verbunden.
HTTP-Anforderung gesendet, auf Antwort wird gewartet … 200 OK
Länge: 71403 (70K) [application/json]
Wird in »ondemand100~_type-video.json« gespeichert.

ondemand100~_type-video.json                         100%[====================================================================================================================>]  69,73K  --.-KB/s    in 0,01s   

2022-03-22 22:45:36 (5,43 MB/s) - »ondemand100~_type-video.json« gespeichert [71403/71403]
```
